### PR TITLE
Add configs for parallelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ These are the commands you can use once it's all set up:
   * Run `./gradlew test -Pmatching=**/special/**/*` to run some tests under a package
 
 
+## Run on parallel forks
+
+There are the number optional properties which lets you to run tests on multiple parallel forks. You can put all or some in `gradle.properties` file:
+
+```
+maxParallelForks=4
+maxHeapSize=4096m
+forkEvery=150
+```
+
+Or you can set up through command line:
+
+  * `./gradlew test -PmaxParallelForks=4 -PmaxHeapSize=4096m -PforkEvery=150`
+
+
 ## Links
 
 Here are a list of useful links:

--- a/gradle-android-test-plugin/src/main/groovy/com/novoda/gradle/test/VariationConfigurator.groovy
+++ b/gradle-android-test-plugin/src/main/groovy/com/novoda/gradle/test/VariationConfigurator.groovy
@@ -74,6 +74,18 @@ class VariationConfigurator {
           testRunTask.include '**/*Spec.class'
         }
 
+        if (project.hasProperty("maxParallelForks")) {
+            testRunTask.setMaxParallelForks(project.maxParallelForks.toInteger())
+        }
+
+        if (project.hasProperty("maxHeapSize")) {
+            testRunTask.setMaxHeapSize(project.maxHeapSize)
+        }
+
+        if (project.hasProperty("forkEvery")) {
+            testRunTask.setForkEvery(project.maxParallelForks.toInteger())
+        }
+
         // Add the path to the correct manifest, resources, assets as a system property.
         testRunTask.systemProperties.put('android.manifest', variationInfo.processedManifestPath)
         testRunTask.systemProperties.put('android.resources', variationInfo.processedResourcesPath)


### PR DESCRIPTION
**The problem**: tests are running on single thread
**The solution**: add properties to set up more forks

![image](https://cloud.githubusercontent.com/assets/38703/5701198/ade5a6e0-9a50-11e4-9a4c-f6aed1bd74ab.png)

 