### PR TITLE
Add debug property

### DIFF
--- a/gradle-android-test-plugin/src/main/groovy/com/novoda/gradle/test/VariationConfigurator.groovy
+++ b/gradle-android-test-plugin/src/main/groovy/com/novoda/gradle/test/VariationConfigurator.groovy
@@ -85,6 +85,9 @@ class VariationConfigurator {
         if (project.hasProperty("forkEvery")) {
             testRunTask.setForkEvery(project.maxParallelForks.toInteger())
         }
+        if (project.hasProperty("testDebug")) {
+            testRunTask.debug(project.testDebug.toBoolean())
+        }
 
         // Add the path to the correct manifest, resources, assets as a system property.
         testRunTask.systemProperties.put('android.manifest', variationInfo.processedManifestPath)


### PR DESCRIPTION
**Problem**: Sometimes is hard to find what is wrong with tests
**Solution**: Use debug

How this is working:

1. First you need to enable debug mode `./gradlew -PtestDebug=true` 
2. Wait until tests will be ready and gradle waits for debugger
3. Make sure you have [remote debug](https://cloud.githubusercontent.com/assets/38703/5818871/bb6e146a-a0c1-11e4-8f73-49616e707c8f.png) configuration on 5005 port
4. start debugging: ![image](https://cloud.githubusercontent.com/assets/38703/5818885/db4846ac-a0c1-11e4-9186-61e32948a21c.png)

Of course you should have been added some breakpoints.

Happy debugging!

