### PR TITLE
revert 969187b because toBoolean does not more exist

### DIFF
--- a/gradle-android-test-plugin/src/main/groovy/com/novoda/gradle/test/VariationConfigurator.groovy
+++ b/gradle-android-test-plugin/src/main/groovy/com/novoda/gradle/test/VariationConfigurator.groovy
@@ -85,9 +85,6 @@ class VariationConfigurator {
         if (project.hasProperty("forkEvery")) {
             testRunTask.setForkEvery(project.maxParallelForks.toInteger())
         }
-        if (project.hasProperty("testDebug")) {
-            testRunTask.debug(project.testDebug.toBoolean())
-        }
 
         // Add the path to the correct manifest, resources, assets as a system property.
         testRunTask.systemProperties.put('android.manifest', variationInfo.processedManifestPath)


### PR DESCRIPTION
This method does not more exist. Fix https://github.com/novoda/gradle-android-test-plugin/issues/34

Instead of searching for alternative we should use Android Studio to run and debug tests. How to https://github.com/nenick/android-gradle-template/wiki/Tests-in-Android-Studio---IntellJ